### PR TITLE
Make 'idle' event fire exactly once.

### DIFF
--- a/lib/poolr.js
+++ b/lib/poolr.js
@@ -68,10 +68,11 @@ Poolr.prototype.runNext = function () {
         process.nextTick(function () {
             this.runNext();
         }.bind(this));
-        if (this.runningJobs < 1) {
+        var result = job.callback(err, res);
+        if (this.runningJobs < 1 && this.queue.length === 0) {
             this.emit('idle');
         }
-        return job.callback(err, res);
+        return result;
     }.bind(this));
     return true;
 };


### PR DESCRIPTION
Only emit 'idle' when queue length is zero - otherwise we occasionally end up
in the situation where all pending requests finalize simultenously, and our
runningJobs count gets down to zero, but we have a bunch of queued jobs which
will be started on the next tick.  This makes it very difficult to wait for
a bunch of queued jobs to finish.

Emit 'idle' event after calling the callback - that seems like more predictable
behavior.
